### PR TITLE
Remove unused ANTHROPIC_BASE_URL secret input

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -7,8 +7,6 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: true
-      ANTHROPIC_BASE_URL:
-        required: false
 
 permissions:
   actions: read

--- a/README.md
+++ b/README.md
@@ -29,17 +29,23 @@ jobs:
     uses: taptap/.github/.github/workflows/code-review.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      # ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}  # optional
 ```
 
 #### Secrets
 
-| Secret               | Required | Description                                     |
-| -------------------- | -------- | ----------------------------------------------- |
-| `ANTHROPIC_API_KEY`  | Yes      | API key for Anthropic                           |
-| `ANTHROPIC_BASE_URL` | No       | Custom API base URL (e.g. for proxy or gateway) |
+| Secret              | Required | Description             |
+| ------------------- | -------- | ----------------------- |
+| `ANTHROPIC_API_KEY` | Yes      | API key for Anthropic   |
 
-Set these as **org-level secrets** so all repos inherit them, or per-repo if needed.
+Set this as an **org-level secret** so all repos inherit it, or per-repo if needed.
+
+#### Variables
+
+| Variable              | Required | Description                                     |
+| --------------------- | -------- | ----------------------------------------------- |
+| `ANTHROPIC_BASE_URL`  | No       | Custom API base URL (e.g. for proxy or gateway) |
+
+Set this as an **org-level variable** (not a secret) if you need to route requests through a proxy.
 
 #### Behavior
 


### PR DESCRIPTION
## Summary
- Remove the unused `ANTHROPIC_BASE_URL` secret from `workflow_call` inputs — the step uses `vars.ANTHROPIC_BASE_URL` (a repo variable) instead, so the secret was never referenced

## Test plan
- [ ] Verify the workflow still triggers correctly on `pull_request` and `workflow_call`
- [ ] Confirm `ANTHROPIC_BASE_URL` is still passed via `vars.*` at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)