### PR TITLE
fix: add checkout step before claude-code-action

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -36,6 +36,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
 
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -67,8 +72,8 @@ jobs:
             Follow the guidelines in REVIEW.md if present.
           claude_args: |
             --model opus
-            --allowedTools "WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),"
+            --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),"
         env:
           GH_TOKEN: ${{ github.token }}
-          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPCI_BASE_URL }}
           ANTHROPIC_CUSTOM_HEADERS: '{"anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14"}'

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -75,5 +75,5 @@ jobs:
             --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),"
         env:
           GH_TOKEN: ${{ github.token }}
-          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPCI_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           ANTHROPIC_CUSTOM_HEADERS: '{"anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14"}'


### PR DESCRIPTION
## Summary

- Add `actions/checkout@v6` step before `claude-code-action` to provide the required `.git` directory
- Add `Read`, `Glob`, `Grep` to `allowedTools` so Claude can read full source files for deeper context-aware review

## Problem

Without `actions/checkout`, the runner workspace has no `.git` directory, causing:

1. `configureGitAuth` fails: `fatal: not in a git directory`
2. `restoreConfigFromBase` fails: `fatal: not a git repository`
3. The entire Code Review action aborts with exit code 1

Evidence: https://github.com/taptap/maker/actions/runs/23711539555/job/69071989009?pr=410

## Test plan

- [ ] Re-run Code Review on an existing PR to verify the action completes successfully
- [ ] Verify Claude can read full source files (not just diff) during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)