### PR TITLE
fix(code-review): dedup prior comments and raise max-turns to 256

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -126,15 +126,20 @@ jobs:
             - Code that "could be better" but works correctly
             - Generated files, lockfiles, vendored code
 
-            ## Output
+            ## Step 3: Output
 
             - Post findings as inline review comments via `mcp__github_inline_comment__create_inline_comment`.
             - Keep the review concise: at most 10 new findings.
-          # Tool surface: inline comments + read-only PR inspection + gh api/pr comment for dedup and summary.
+            - After all inline comments are posted, publish ONE summary comment via `gh pr comment ${{ github.event.pull_request.number || inputs.pr_number }} --body "..."`. Format:
+              - One-line verdict: ✅ Approved / ⚠️ Issues Found / 🔴 Changes Requested
+              - If any prior comments were resolved this run: "N previously reported issues fixed."
+              - List of new findings with severity (🔴 P1 / 🟡 P2 / 🟢 P3) and confidence.
+              - Brief overall assessment.
+          # Tool surface: inline comments + read-only PR inspection + scoped gh api (PR comments + GraphQL only) + gh pr comment for summary.
           claude_args: |
             --model opus
             --max-turns 256
-            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*)"
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh api repos/*/pulls/*/comments*),Bash(gh api graphql*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*)"
         env:
           GH_TOKEN: ${{ github.token }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL || 'https://api.anthropic.com' }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -81,19 +81,60 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Review this pull request for code quality, correctness, and security.
-            Analyze the diff in the context of the full codebase.
-            Only report actionable findings that are specific and important.
-            Use these severity levels in each finding: P1 for blocking or high-risk issues, P2 for meaningful issues, P3 for minor issues.
-            Skip generated files, lockfiles, vendored code, and style-only nits unless they hide a real bug.
-            Keep the review concise: at most 10 findings total.
-            Post findings as inline review comments on the specific lines where issues are found.
-            Follow the guidelines in REVIEW.md if present.
-          # Keep the tool surface narrow: inline comments plus read-only PR inspection.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+            You are a senior code reviewer. The goal is to surface real, actionable issues — not noise.
+
+            ## Step 1: Reconcile previous review comments
+
+            Before reviewing anything new, handle your prior comments on this PR so issues are not reported twice across commits.
+
+            1. Fetch your previous inline comments:
+               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || inputs.pr_number }}/comments --jq '[.[] | select(.user.login == "claude[bot]")]'`
+            2. Fetch the current diff: `gh pr diff ${{ github.event.pull_request.number || inputs.pr_number }}`
+            3. For each previous comment, read the **current** version of the file and check whether the issue is fixed:
+               - **Fixed**: reply with `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || inputs.pr_number }}/comments/{comment_id}/replies -f body="✅ Fixed. {brief description of the fix}"`, then resolve the thread (step 5).
+               - **Still present**: reply explaining it is still unresolved. **Do NOT open a new inline comment for the same issue.**
+               - **Partially fixed**: reply describing what remains.
+            4. Only open new inline comments for **genuinely new issues** not covered by any previous comment.
+            5. After replying to fixed comments, resolve their threads:
+               a. Get review thread IDs:
+                  `gh api graphql -f query='{ repository(owner:"${{ github.repository_owner }}", name:"${{ github.event.repository.name }}") { pullRequest(number:${{ github.event.pull_request.number || inputs.pr_number }}) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { databaseId body } } } } } } }'`
+               b. Match each fixed comment's databaseId to its thread node ID.
+               c. Resolve: `gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"THREAD_NODE_ID"}) { thread { isResolved } } }'`
+
+            ## Step 2: Review the new changes
+
+            Analyze the diff in the context of the full codebase. For each changed file, read the **full source** (not just the diff hunk) to understand context. Use `git blame` / `git log` on suspicious lines to understand history. Follow the guidelines in REVIEW.md if present.
+
+            ## Confidence and severity
+
+            Score every finding 0-100. Only report findings with confidence ≥ 75.
+            - 90-100: certain bug or security issue
+            - 75-89: highly confident, very likely a real problem
+            - <75: do not report
+
+            Use severity levels: P1 (blocking / high-risk), P2 (meaningful), P3 (minor).
+
+            ## False-positive filters — do NOT report
+
+            - Issues that already existed before this PR
+            - Style preferences or nits that a linter/formatter handles
+            - Missing comments on self-explanatory code
+            - Hypothetical future problems
+            - Code that "could be better" but works correctly
+            - Generated files, lockfiles, vendored code
+
+            ## Output
+
+            - Post findings as inline review comments via `mcp__github_inline_comment__create_inline_comment`.
+            - Keep the review concise: at most 10 new findings.
+          # Tool surface: inline comments + read-only PR inspection + gh api/pr comment for dedup and summary.
           claude_args: |
             --model opus
-            --max-turns 30
-            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*)"
+            --max-turns 256
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*)"
         env:
           GH_TOKEN: ${{ github.token }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL || 'https://api.anthropic.com' }}


### PR DESCRIPTION
## Summary

- **Stop duplicate review comments across pushes.** Add a Step 1 to the prompt that pulls prior `claude[bot]` inline comments, checks each against the current source, replies (✅ Fixed / still present / partially fixed) and resolves the threads that are fixed — instead of re-opening the same finding every push.
- **Raise `--max-turns` from 30 to 256.** Observed on `taptap/maker#439`: non-trivial PRs hit `error_max_turns` after ~4 min and aborted before any comment was posted. 30 was a hard cap, not a budget — small PRs still use few turns.
- **Tighten the prompt**: confidence ≥ 75 threshold and an explicit false-positive filter list, modeled on the working pattern from `taptap/UrhoX/.github/workflows/pr-review.yml` (org-generic parts only — no language-specific checks).
- **Expand `allowedTools`**: add `Bash(gh api:*)` and `Bash(gh pr comment:*)` because the dedup logic needs `gh api` for the comments endpoint and the GraphQL `resolveReviewThread` mutation.

## Why org-wide and not per-repo

The reusable workflow exposes only `pr_number / is_draft / head_repo_full_name` as inputs, so consumers (e.g. `maker/.github/workflows/code-review.yml`) cannot override the prompt or args today. All four changes here are bug fixes / generic quality improvements — no language- or project-specific content was copied from UrhoX. If a repo later wants specialization, the right move is to add a `extra_prompt` / `max_turns` input to this workflow, not to fork it.

## Test plan

- [ ] Open a PR in a consumer repo (e.g. `taptap/maker`) and verify the Code Review job reaches the Claude step and posts inline comments.
- [ ] Push a follow-up commit that fixes one of the reported issues; confirm Claude replies "✅ Fixed" and resolves that thread instead of opening a new comment.
- [ ] Push a follow-up commit that does NOT fix a reported issue; confirm Claude replies "still unresolved" and does NOT re-open the same finding.
- [ ] Confirm a large PR no longer aborts with `error_max_turns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)