### PR TITLE
🔧 chore(deps): bump patch dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "prettier": "^3.8.3",
-    "typescript-eslint": "^8.59.3"
+    "typescript-eslint": "^8.59.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^3.8.3
         version: 3.8.3
       typescript-eslint:
-        specifier: ^8.59.3
-        version: 8.59.3(eslint@10.4.0)(typescript@5.9.3)
+        specifier: ^8.59.4
+        version: 8.59.4(eslint@10.4.0)(typescript@5.9.3)
 
 packages:
   "@eslint-community/eslint-utils@4.9.1":
@@ -149,92 +149,92 @@ packages:
         integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.59.3":
+  "@typescript-eslint/eslint-plugin@8.59.4":
     resolution:
       {
-        integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==,
+        integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.59.3
+      "@typescript-eslint/parser": ^8.59.4
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.59.3":
+  "@typescript-eslint/parser@8.59.4":
     resolution:
       {
-        integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/project-service@8.59.3":
-    resolution:
-      {
-        integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/scope-manager@8.59.3":
-    resolution:
-      {
-        integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/tsconfig-utils@8.59.3":
-    resolution:
-      {
-        integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/type-utils@8.59.3":
-    resolution:
-      {
-        integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==,
+        integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.59.3":
+  "@typescript-eslint/project-service@8.59.4":
     resolution:
       {
-        integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.59.3":
-    resolution:
-      {
-        integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==,
+        integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.59.3":
+  "@typescript-eslint/scope-manager@8.59.4":
     resolution:
       {
-        integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==,
+        integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.59.4":
+    resolution:
+      {
+        integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.59.4":
+    resolution:
+      {
+        integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.59.3":
+  "@typescript-eslint/types@8.59.4":
     resolution:
       {
-        integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==,
+        integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/typescript-estree@8.59.4":
+    resolution:
+      {
+        integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.59.4":
+    resolution:
+      {
+        integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.59.4":
+    resolution:
+      {
+        integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -889,10 +889,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  typescript-eslint@8.59.3:
+  typescript-eslint@8.59.4:
     resolution:
       {
-        integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==,
+        integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -1014,14 +1014,14 @@ snapshots:
 
   "@types/json-schema@7.0.15": {}
 
-  "@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.59.3(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/scope-manager": 8.59.3
-      "@typescript-eslint/type-utils": 8.59.3(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.59.3(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.59.3
+      "@typescript-eslint/parser": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.59.4
+      "@typescript-eslint/type-utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.59.4
       eslint: 10.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1030,41 +1030,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.59.3(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.59.3
-      "@typescript-eslint/types": 8.59.3
-      "@typescript-eslint/typescript-estree": 8.59.3(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.59.3
+      "@typescript-eslint/scope-manager": 8.59.4
+      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.59.4
       debug: 4.4.3
       eslint: 10.4.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.59.3(typescript@5.9.3)":
+  "@typescript-eslint/project-service@8.59.4(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.59.3(typescript@5.9.3)
-      "@typescript-eslint/types": 8.59.3
+      "@typescript-eslint/tsconfig-utils": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/types": 8.59.4
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.59.3":
+  "@typescript-eslint/scope-manager@8.59.4":
     dependencies:
-      "@typescript-eslint/types": 8.59.3
-      "@typescript-eslint/visitor-keys": 8.59.3
+      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/visitor-keys": 8.59.4
 
-  "@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.9.3)":
+  "@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)":
     dependencies:
       typescript: 5.9.3
 
-  "@typescript-eslint/type-utils@8.59.3(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/type-utils@8.59.4(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/types": 8.59.3
-      "@typescript-eslint/typescript-estree": 8.59.3(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.59.3(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 10.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -1072,14 +1072,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.59.3": {}
+  "@typescript-eslint/types@8.59.4": {}
 
-  "@typescript-eslint/typescript-estree@8.59.3(typescript@5.9.3)":
+  "@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.59.3(typescript@5.9.3)
-      "@typescript-eslint/tsconfig-utils": 8.59.3(typescript@5.9.3)
-      "@typescript-eslint/types": 8.59.3
-      "@typescript-eslint/visitor-keys": 8.59.3
+      "@typescript-eslint/project-service": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/tsconfig-utils": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/visitor-keys": 8.59.4
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.0
@@ -1089,20 +1089,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.59.3(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/utils@8.59.4(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
       "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.0)
-      "@typescript-eslint/scope-manager": 8.59.3
-      "@typescript-eslint/types": 8.59.3
-      "@typescript-eslint/typescript-estree": 8.59.3(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.59.4
+      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
       eslint: 10.4.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.59.3":
+  "@typescript-eslint/visitor-keys@8.59.4":
     dependencies:
-      "@typescript-eslint/types": 8.59.3
+      "@typescript-eslint/types": 8.59.4
       eslint-visitor-keys: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -1448,12 +1448,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.59.3(eslint@10.4.0)(typescript@5.9.3):
+  typescript-eslint@8.59.4(eslint@10.4.0)(typescript@5.9.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/parser": 8.59.3(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/typescript-estree": 8.59.3(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.59.3(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/eslint-plugin": 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
       eslint: 10.4.0
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Bump `typescript-eslint` from `^8.59.3` to `^8.59.4`.
- Leave `pnpm` unchanged at 11.1.3; `npm view pnpm version` also reports 11.1.3.

## Risk
- Patch-only tooling update. No migration expected.

## Validation
- `pnpm outdated --format json` -> `{}`
- `pnpm run lint`