### PR TITLE
chore(deps): bump pnpm to 11.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
+  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary
- bump the checked-in `packageManager` pin from `pnpm@11.2.2` to `pnpm@11.3.0`
- leave `pnpm-lock.yaml` unchanged because the frozen install stayed current

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run lint`
- `corepack pnpm outdated --format json` -> `{}`

## Risk
- low: `pnpm@11.3.0` keeps the same Node floor (`>=22.13`), while this repo requires Node `>=22.22.1` and was validated on Node `24.16.0`.