### PR TITLE
🔧 chore(deps): refresh package pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "prettier": "^3.8.3",
-    "typescript-eslint": "^8.59.4"
+    "typescript-eslint": "^8.60.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^3.8.3
         version: 3.8.3
       typescript-eslint:
-        specifier: ^8.59.4
-        version: 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+        specifier: ^8.60.0
+        version: 8.60.0(eslint@10.4.0)(typescript@5.9.3)
 
 packages:
   "@eslint-community/eslint-utils@4.9.1":
@@ -149,92 +149,92 @@ packages:
         integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.59.4":
+  "@typescript-eslint/eslint-plugin@8.60.0":
     resolution:
       {
-        integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==,
+        integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.59.4
+      "@typescript-eslint/parser": ^8.60.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.59.4":
+  "@typescript-eslint/parser@8.60.0":
     resolution:
       {
-        integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/project-service@8.59.4":
-    resolution:
-      {
-        integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/scope-manager@8.59.4":
-    resolution:
-      {
-        integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/tsconfig-utils@8.59.4":
-    resolution:
-      {
-        integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/type-utils@8.59.4":
-    resolution:
-      {
-        integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==,
+        integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.59.4":
+  "@typescript-eslint/project-service@8.60.0":
     resolution:
       {
-        integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.59.4":
-    resolution:
-      {
-        integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==,
+        integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.59.4":
+  "@typescript-eslint/scope-manager@8.60.0":
     resolution:
       {
-        integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==,
+        integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.60.0":
+    resolution:
+      {
+        integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.60.0":
+    resolution:
+      {
+        integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.59.4":
+  "@typescript-eslint/types@8.60.0":
     resolution:
       {
-        integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==,
+        integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/typescript-estree@8.60.0":
+    resolution:
+      {
+        integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.60.0":
+    resolution:
+      {
+        integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.60.0":
+    resolution:
+      {
+        integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -788,10 +788,10 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
-  semver@7.8.0:
+  semver@7.8.1:
     resolution:
       {
-        integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==,
+        integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==,
       }
     engines: { node: ">=10" }
     hasBin: true
@@ -889,10 +889,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  typescript-eslint@8.59.4:
+  typescript-eslint@8.60.0:
     resolution:
       {
-        integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==,
+        integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -1014,14 +1014,14 @@ snapshots:
 
   "@types/json-schema@7.0.15": {}
 
-  "@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/scope-manager": 8.59.4
-      "@typescript-eslint/type-utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.59.4
+      "@typescript-eslint/parser": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.60.0
+      "@typescript-eslint/type-utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.60.0
       eslint: 10.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1030,41 +1030,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.59.4
-      "@typescript-eslint/types": 8.59.4
-      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.59.4
+      "@typescript-eslint/scope-manager": 8.60.0
+      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.60.0
       debug: 4.4.3
       eslint: 10.4.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.59.4(typescript@5.9.3)":
+  "@typescript-eslint/project-service@8.60.0(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.59.4(typescript@5.9.3)
-      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/tsconfig-utils": 8.60.0(typescript@5.9.3)
+      "@typescript-eslint/types": 8.60.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.59.4":
+  "@typescript-eslint/scope-manager@8.60.0":
     dependencies:
-      "@typescript-eslint/types": 8.59.4
-      "@typescript-eslint/visitor-keys": 8.59.4
+      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/visitor-keys": 8.60.0
 
-  "@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)":
+  "@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)":
     dependencies:
       typescript: 5.9.3
 
-  "@typescript-eslint/type-utils@8.59.4(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/type-utils@8.60.0(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/types": 8.59.4
-      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 10.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -1072,37 +1072,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.59.4": {}
+  "@typescript-eslint/types@8.60.0": {}
 
-  "@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)":
+  "@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.59.4(typescript@5.9.3)
-      "@typescript-eslint/tsconfig-utils": 8.59.4(typescript@5.9.3)
-      "@typescript-eslint/types": 8.59.4
-      "@typescript-eslint/visitor-keys": 8.59.4
+      "@typescript-eslint/project-service": 8.60.0(typescript@5.9.3)
+      "@typescript-eslint/tsconfig-utils": 8.60.0(typescript@5.9.3)
+      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/visitor-keys": 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.0
+      semver: 7.8.1
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.59.4(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/utils@8.60.0(eslint@10.4.0)(typescript@5.9.3)":
     dependencies:
       "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.0)
-      "@typescript-eslint/scope-manager": 8.59.4
-      "@typescript-eslint/types": 8.59.4
-      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.60.0
+      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
       eslint: 10.4.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.59.4":
+  "@typescript-eslint/visitor-keys@8.60.0":
     dependencies:
-      "@typescript-eslint/types": 8.59.4
+      "@typescript-eslint/types": 8.60.0
       eslint-visitor-keys: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -1396,7 +1396,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  semver@7.8.0: {}
+  semver@7.8.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -1448,12 +1448,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.59.4(eslint@10.4.0)(typescript@5.9.3):
+  typescript-eslint@8.60.0(eslint@10.4.0)(typescript@5.9.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/parser": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/typescript-estree": 8.59.4(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.59.4(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/eslint-plugin": 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
       eslint: 10.4.0
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- update `typescript-eslint` from `^8.59.4` to `^8.60.0`
- refresh `pnpm-lock.yaml` with the pinned package manager

## Risk
- Patch/minor tooling-only update; no runtime dependency changes.
- No known breaking-change migration required.

## Validation
- `pnpm lint`