### PR TITLE
chore(deps): bump pnpm to 11.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary
- bump packageManager from pnpm 11.3.0 to 11.4.0
- leave direct dependencies unchanged after `pnpm outdated --format json` returned `{}`

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm outdated --format json` -> `{}`
- `corepack pnpm run lint`

## Risk
- No breaking migration expected: pnpm stays on major 11 and keeps the same Node engine floor (`>=22.13`).