### PR TITLE
🔧 chore(deps): bump pnpm to 11.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,10 +859,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  tinyexec@1.1.2:
+  tinyexec@1.2.2:
     resolution:
       {
-        integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==,
+        integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==,
       }
     engines: { node: ">=18" }
 
@@ -1322,7 +1322,7 @@ snapshots:
       listr2: 10.2.1
       picomatch: 4.0.4
       string-argv: 0.3.2
-      tinyexec: 1.1.2
+      tinyexec: 1.2.2
     optionalDependencies:
       yaml: 2.9.0
 
@@ -1433,7 +1433,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  tinyexec@1.1.2: {}
+  tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
## Summary
- bump `packageManager` from pnpm 11.4.0 to 11.5.0
- refresh lockfile metadata within existing dependency ranges

## Risk
- Low: same pnpm major, no runtime package manifest changes beyond Corepack metadata.

## Verification
- `pnpm lint`