### PR TITLE
🔧 chore(deps): refresh shared tooling patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",
@@ -10,11 +10,11 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "autocorrect-node": "^2.14.0",
-    "eslint": "^10.4.0",
+    "eslint": "^10.4.1",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.5",
+    "lint-staged": "^17.0.7",
     "prettier": "^3.8.3",
-    "typescript-eslint": "^8.60.0"
+    "typescript-eslint": "^8.60.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ importers:
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.4.0)
+        version: 10.0.1(eslint@10.4.1)
       autocorrect-node:
         specifier: ^2.14.0
         version: 2.14.0
       eslint:
-        specifier: ^10.4.0
-        version: 10.4.0
+        specifier: ^10.4.1
+        version: 10.4.1
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -23,14 +23,14 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.0.5
-        version: 17.0.5
+        specifier: ^17.0.7
+        version: 17.0.7
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
       typescript-eslint:
-        specifier: ^8.60.0
-        version: 8.60.0(eslint@10.4.0)(typescript@5.9.3)
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@10.4.1)(typescript@5.9.3)
 
 packages:
   "@eslint-community/eslint-utils@4.9.1":
@@ -89,10 +89,10 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/plugin-kit@0.7.1":
+  "@eslint/plugin-kit@0.7.2":
     resolution:
       {
-        integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==,
+        integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
@@ -149,92 +149,92 @@ packages:
         integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.60.0":
+  "@typescript-eslint/eslint-plugin@8.60.1":
     resolution:
       {
-        integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==,
+        integrity: sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.60.0
+      "@typescript-eslint/parser": ^8.60.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.60.0":
+  "@typescript-eslint/parser@8.60.1":
     resolution:
       {
-        integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/project-service@8.60.0":
-    resolution:
-      {
-        integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/scope-manager@8.60.0":
-    resolution:
-      {
-        integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/tsconfig-utils@8.60.0":
-    resolution:
-      {
-        integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/type-utils@8.60.0":
-    resolution:
-      {
-        integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==,
+        integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.60.0":
+  "@typescript-eslint/project-service@8.60.1":
     resolution:
       {
-        integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.60.0":
-    resolution:
-      {
-        integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==,
+        integrity: sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.60.0":
+  "@typescript-eslint/scope-manager@8.60.1":
     resolution:
       {
-        integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==,
+        integrity: sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.60.1":
+    resolution:
+      {
+        integrity: sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.60.1":
+    resolution:
+      {
+        integrity: sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.60.0":
+  "@typescript-eslint/types@8.60.1":
     resolution:
       {
-        integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==,
+        integrity: sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/typescript-estree@8.60.1":
+    resolution:
+      {
+        integrity: sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.60.1":
+    resolution:
+      {
+        integrity: sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.60.1":
+    resolution:
+      {
+        integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -430,10 +430,10 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  eslint@10.4.0:
+  eslint@10.4.1:
     resolution:
       {
-        integrity: sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==,
+        integrity: sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     hasBin: true
@@ -649,10 +649,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  lint-staged@17.0.5:
+  lint-staged@17.0.7:
     resolution:
       {
-        integrity: sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==,
+        integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==,
       }
     engines: { node: ">=22.22.1" }
     hasBin: true
@@ -859,10 +859,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  tinyexec@1.2.2:
+  tinyexec@1.2.4:
     resolution:
       {
-        integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==,
+        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
       }
     engines: { node: ">=18" }
 
@@ -889,10 +889,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  typescript-eslint@8.60.0:
+  typescript-eslint@8.60.1:
     resolution:
       {
-        integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==,
+        integrity: sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -958,9 +958,9 @@ packages:
     engines: { node: ">=10" }
 
 snapshots:
-  "@eslint-community/eslint-utils@4.9.1(eslint@10.4.0)":
+  "@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)":
     dependencies:
-      eslint: 10.4.0
+      eslint: 10.4.1
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.2": {}
@@ -981,13 +981,13 @@ snapshots:
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/js@10.0.1(eslint@10.4.0)":
+  "@eslint/js@10.0.1(eslint@10.4.1)":
     optionalDependencies:
-      eslint: 10.4.0
+      eslint: 10.4.1
 
   "@eslint/object-schema@3.0.5": {}
 
-  "@eslint/plugin-kit@0.7.1":
+  "@eslint/plugin-kit@0.7.2":
     dependencies:
       "@eslint/core": 1.2.1
       levn: 0.4.1
@@ -1014,15 +1014,15 @@ snapshots:
 
   "@types/json-schema@7.0.15": {}
 
-  "@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@5.9.3))(eslint@10.4.1)(typescript@5.9.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/scope-manager": 8.60.0
-      "@typescript-eslint/type-utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.60.0
-      eslint: 10.4.0
+      "@typescript-eslint/parser": 8.60.1(eslint@10.4.1)(typescript@5.9.3)
+      "@typescript-eslint/scope-manager": 8.60.1
+      "@typescript-eslint/type-utils": 8.60.1(eslint@10.4.1)(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.60.1(eslint@10.4.1)(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.60.1
+      eslint: 10.4.1
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -1030,56 +1030,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.60.0
-      "@typescript-eslint/types": 8.60.0
-      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.60.0
+      "@typescript-eslint/scope-manager": 8.60.1
+      "@typescript-eslint/types": 8.60.1
+      "@typescript-eslint/typescript-estree": 8.60.1(typescript@5.9.3)
+      "@typescript-eslint/visitor-keys": 8.60.1
       debug: 4.4.3
-      eslint: 10.4.0
+      eslint: 10.4.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.60.0(typescript@5.9.3)":
+  "@typescript-eslint/project-service@8.60.1(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.60.0(typescript@5.9.3)
-      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/tsconfig-utils": 8.60.1(typescript@5.9.3)
+      "@typescript-eslint/types": 8.60.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.60.0":
+  "@typescript-eslint/scope-manager@8.60.1":
     dependencies:
-      "@typescript-eslint/types": 8.60.0
-      "@typescript-eslint/visitor-keys": 8.60.0
+      "@typescript-eslint/types": 8.60.1
+      "@typescript-eslint/visitor-keys": 8.60.1
 
-  "@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)":
+  "@typescript-eslint/tsconfig-utils@8.60.1(typescript@5.9.3)":
     dependencies:
       typescript: 5.9.3
 
-  "@typescript-eslint/type-utils@8.60.0(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/type-utils@8.60.1(eslint@10.4.1)(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/types": 8.60.0
-      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
+      "@typescript-eslint/types": 8.60.1
+      "@typescript-eslint/typescript-estree": 8.60.1(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.60.1(eslint@10.4.1)(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.4.0
+      eslint: 10.4.1
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.60.0": {}
+  "@typescript-eslint/types@8.60.1": {}
 
-  "@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)":
+  "@typescript-eslint/typescript-estree@8.60.1(typescript@5.9.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.60.0(typescript@5.9.3)
-      "@typescript-eslint/tsconfig-utils": 8.60.0(typescript@5.9.3)
-      "@typescript-eslint/types": 8.60.0
-      "@typescript-eslint/visitor-keys": 8.60.0
+      "@typescript-eslint/project-service": 8.60.1(typescript@5.9.3)
+      "@typescript-eslint/tsconfig-utils": 8.60.1(typescript@5.9.3)
+      "@typescript-eslint/types": 8.60.1
+      "@typescript-eslint/visitor-keys": 8.60.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.1
@@ -1089,20 +1089,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.60.0(eslint@10.4.0)(typescript@5.9.3)":
+  "@typescript-eslint/utils@8.60.1(eslint@10.4.1)(typescript@5.9.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.0)
-      "@typescript-eslint/scope-manager": 8.60.0
-      "@typescript-eslint/types": 8.60.0
-      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
-      eslint: 10.4.0
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1)
+      "@typescript-eslint/scope-manager": 8.60.1
+      "@typescript-eslint/types": 8.60.1
+      "@typescript-eslint/typescript-estree": 8.60.1(typescript@5.9.3)
+      eslint: 10.4.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.60.0":
+  "@typescript-eslint/visitor-keys@8.60.1":
     dependencies:
-      "@typescript-eslint/types": 8.60.0
+      "@typescript-eslint/types": 8.60.1
       eslint-visitor-keys: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -1193,14 +1193,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.0:
+  eslint@10.4.1:
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.0)
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1)
       "@eslint-community/regexpp": 4.12.2
       "@eslint/config-array": 0.23.5
       "@eslint/config-helpers": 0.6.0
       "@eslint/core": 1.2.1
-      "@eslint/plugin-kit": 0.7.1
+      "@eslint/plugin-kit": 0.7.2
       "@humanfs/node": 0.16.8
       "@humanwhocodes/module-importer": 1.0.1
       "@humanwhocodes/retry": 0.4.3
@@ -1317,12 +1317,12 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lint-staged@17.0.5:
+  lint-staged@17.0.7:
     dependencies:
       listr2: 10.2.1
       picomatch: 4.0.4
       string-argv: 0.3.2
-      tinyexec: 1.2.2
+      tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
 
@@ -1433,7 +1433,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  tinyexec@1.2.2: {}
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -1448,13 +1448,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.60.0(eslint@10.4.0)(typescript@5.9.3):
+  typescript-eslint@8.60.1(eslint@10.4.1)(typescript@5.9.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/parser": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
-      "@typescript-eslint/typescript-estree": 8.60.0(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.60.0(eslint@10.4.0)(typescript@5.9.3)
-      eslint: 10.4.0
+      "@typescript-eslint/eslint-plugin": 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@5.9.3))(eslint@10.4.1)(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.60.1(eslint@10.4.1)(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.60.1(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.60.1(eslint@10.4.1)(typescript@5.9.3)
+      eslint: 10.4.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Updates the TapTap shared workflow tooling with the smallest safe patch set still outstanding on this PR.

- Bumps `packageManager` from `pnpm@11.5.0` to the current published `pnpm@11.5.2`.
- Bumps `lint-staged` from `17.0.6` to `17.0.7`.
- Bumps `typescript-eslint` from `8.60.0` to `8.60.1`.
- Keeps the existing `eslint@10.4.1` patch from this PR.

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm outdated --format json` -> `{}`
- `pnpm run lint`