### PR TITLE
feat(code-review): 增加 request_copilot_review 开关，支持按仓库关闭 Copilot review

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -20,6 +20,11 @@ on:
         description: Head repository full name for same-repo validation.
         required: false
         type: string
+      request_copilot_review:
+        description: Whether to add @copilot as a PR reviewer. Set false to opt out per repository.
+        required: false
+        default: true
+        type: boolean
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -62,6 +67,9 @@ jobs:
     steps:
       - name: Request Copilot review
         # Copilot review is optional. Keep Claude review running if this request is unavailable.
+        # Reusable callers can opt out per repository by passing `request_copilot_review: false`.
+        # Direct `pull_request` runs (no inputs) keep requesting Copilot as before.
+        if: ${{ github.event_name != 'workflow_call' || inputs.request_copilot_review }}
         continue-on-error: true
         run: |
           gh pr edit "$PR_NUMBER" -R "$REPO" --add-reviewer @copilot


### PR DESCRIPTION
## 变更概述
- reusable workflow `code-review.yml` 新增 `workflow_call` 输入 `request_copilot_review`（boolean，默认 `true`）
- 「Request Copilot review」步骤增加 `if: github.event_name != 'workflow_call' || inputs.request_copilot_review`
- 调用方传 `request_copilot_review: false` 即可只保留 Claude review、不再 `--add-reviewer @copilot`

## 行为说明
- **默认不变**：未传该输入的调用方仍会请求 Copilot
- **直接 `pull_request` 触发**（本仓自身 PR）不受影响，照常请求 Copilot
- **首个消费方**：`taptap/maker` 将传 `false`（见对应 PR）

## 测试计划
- [ ] merge 后，maker 侧 PR 的 Code Review workflow 不再添加 @copilot，Claude review 正常运行
- [ ] 其它未改动的调用仓 Copilot review 行为保持不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)