### PR TITLE
🔧 chore(deps): bump pnpm to 11.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620",
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary
- Bump the repo packageManager pin to pnpm 11.8.0 after the release-age window.
- Leave dependency ranges and the lockfile unchanged.

## Validation
- CI=true npm exec --yes pnpm@11.8.0 -- install --frozen-lockfile --ignore-scripts
- npm exec --yes pnpm@11.8.0 -- run lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

将 `packageManager` 字段中固定的 pnpm 版本从 11.7.0 升级至 11.8.0，同时更新对应的 SHA512 校验哈希，依赖范围与 lockfile 均保持不变。

- `package.json` 中 `packageManager` 字段的版本号与 SHA512 哈希同步更新，新哈希长度为 128 个十六进制字符，符合 SHA512 格式。
- PR 描述中提供了通过 `--frozen-lockfile` 安装及 lint 的验证步骤，变更范围极小，风险低。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

此 PR 仅修改 packageManager 版本号与对应 SHA512 哈希，可安全合并。

改动范围极小，只有一行变更：pnpm 版本号从 11.7.0 更新为 11.8.0，SHA512 哈希格式正确（128 位十六进制字符）。lockfile 与依赖范围均未改动，PR 作者也在描述中提供了 frozen-lockfile 安装和 lint 的验证记录。

无文件需要特别关注。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | 将 pnpm 从 11.7.0 升级至 11.8.0，同步更新 SHA512 校验哈希，其余内容无改动 |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json\npackageManager 字段] --> B{corepack 校验}
    B -->|版本匹配 + SHA512 验证通过| C[使用 pnpm 11.8.0]
    B -->|版本或哈希不匹配| D[安装失败]
    C --> E[pnpm install --frozen-lockfile]
    E --> F[pnpm run lint]
    F --> G[✅ CI 通过]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json\npackageManager 字段] --> B{corepack 校验}
    B -->|版本匹配 + SHA512 验证通过| C[使用 pnpm 11.8.0]
    B -->|版本或哈希不匹配| D[安装失败]
    C --> E[pnpm install --frozen-lockfile]
    E --> F[pnpm run lint]
    F --> G[✅ CI 通过]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["🔧 chore(deps): bump pnpm to 11.8.0"](https://github.com/taptap/.github/commit/a6e81a08ebc524bf2336322864baab9f8dcab2f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38981343)</sub>

<!-- /greptile_comment -->