### PR TITLE
🔧 chore(deps): bump pnpm to 11.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary
- bump the declared package manager from pnpm 11.9.0 to 11.10.0
- keep the lockfile unchanged

## Validation
- `CI=true npm exec --yes pnpm@11.10.0 -- install --frozen-lockfile --ignore-scripts`
- `npm exec --yes pnpm@11.10.0 -- run lint`
- `npm exec --yes pnpm@11.10.0 -- audit --audit-level low --json` returned 0 advisories