### PR TITLE
🔧 chore(deps): bump pnpm to 11.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary

- update the pinned package manager from pnpm 11.10.0 to 11.11.0
- preserve the existing lockfile and dependency graph

## Why

This keeps the repository on the current pnpm 11 release after the fresh-release safety window. The change is limited to the Corepack package-manager version and verified integrity hash.

## Impact

No dependency ranges, resolved packages, runtime code, or migration steps change.

## Validation

- frozen install with pnpm 11.11.0
- repository lint suite
- pnpm audit
