### PR TITLE
✨ feat(code-review): add configurable model input

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: true
         type: boolean
+      model:
+        description: Claude model alias (opus / sonnet / haiku) or full model ID.
+        required: false
+        type: string
+        default: opus
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -145,7 +150,7 @@ jobs:
               - Brief overall assessment.
           # Tool surface: inline comments + read-only PR inspection + scoped gh api (PR comments + GraphQL only) + gh pr comment for summary.
           claude_args: |
-            --model opus
+            --model ${{ inputs.model || 'opus' }}
             --max-turns 256
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh api repos/*/pulls/*/comments*),Bash(gh api graphql*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*)"
         env:


### PR DESCRIPTION
## 背景

共享 code-review workflow 把 `--model opus` 写死，consumer repo 想换 review 模型只能整段抄走 workflow（放弃复用）。这是 [RFC 0001](https://github.com/taptap/.github/blob/main/docs/rfcs/0001-code-review-customization.md) Phase 1 里 `model` 参数的落地。

## 改动

- 新增 `model` input（`required: false`，`default: opus`）。
- `--model opus` → `--model ${{ inputs.model || 'opus' }}`。

`|| 'opus'` fallback 的必要性：该 workflow 同时被 `pull_request` 直接触发（review taptap/.github 自身 PR），此时 `workflow_call` 的 inputs 未填充，`inputs.model` 为空——fallback 保证直接触发时仍走 opus。

## 兼容性

完全向后兼容：所有现有 caller（未传 `model`）默认 opus，行为不变。

## 首个消费方

maker 将传 `model: fable-5`（见 taptap/maker 侧 PR）。**合并顺序**：本 PR 需先合入 main，maker 侧 PR 才能生效（否则 maker 传一个 workflow 尚不认识的 input 会导致校验失败）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)