### PR TITLE
🔧 chore(deps): bump pnpm to 11.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary

- update the pinned package manager to pnpm 11.12.0
- preserve the existing lockfile and dependency graph

## Why

This keeps the repository on the current pnpm 11 release after the fresh-release safety window. The change is limited to the Corepack package-manager version and verified integrity hash.

## Impact

No dependency ranges, resolved packages, runtime code, or migration steps change.

## Validation

- frozen install with pnpm 11.12.0
- repository lint suite
- pnpm audit
