### PR TITLE
🔧 chore(deps): bump pnpm to 11.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
+  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary

- Update pnpm from 11.12.0 to 11.13.1.
- Keep the integrity-qualified package-manager pin current without changing the dependency graph.

## Validation

- Frozen install and repository lint passed.
- `pnpm-lock.yaml` is unchanged.

## Risk

Low: this stays within pnpm 11 and does not require a migration. Repositories with mise or documented pins keep those references aligned.