### PR TITLE
fix(deps): patch brace-expansion DoS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,10 +343,10 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     resolution:
       {
-        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+        integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -1151,7 +1151,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1350,7 +1350,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary\n\n- Resolve brace-expansion from 5.0.6 to 5.0.7 in the lockfile.\n- Fix the high-severity exponential expansion denial of service advisory.\n- Keep package manifests and dependency ranges unchanged.\n\n## Validation\n\n- Frozen pnpm install\n- Repository lint suite\n- git diff --check\n\n## Risk\n\nPatch-only transitive development dependency update. No breaking change or migration is required.