### PR TITLE
chore(deps): bump pnpm to 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary\n\n- Bump the verified packageManager pin from pnpm 11.13.1 to 11.15.1.\n- Preserve the dependency graph and pnpm-lock.yaml.\n- Align repository-local tool pins where present.\n\n## Validation\n\n- Frozen install with pnpm 11.15.1\n- Repository lint suite\n- git diff --check\n\n## Risk\n\nSame-major package-manager-only update. No dependency migration or lockfile regeneration is required.