### PR TITLE
🔧 chore(deps): bump pnpm to 11.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "scripts": {
     "format": "prettier --write --ignore-unknown --log-level=warn . && autocorrect --fix .",
     "lint": "eslint . --no-error-on-unmatched-pattern && pnpm run --filter '*' lint && prettier --check --ignore-unknown .",


### PR DESCRIPTION
## Summary

- update pnpm from 11.15.1 to 11.17.0 within the existing major version
- refresh the packageManager integrity pin; keep the dependency lockfile unchanged
- align checked-in pnpm pins where the repository documents or configures them

## Validation

- installed with the exact pnpm 11.17.0 binary using the frozen lockfile and offline cache
- passed the repository supply-chain policy and full lint/type-check suite
- confirmed no dependency migration or lockfile rewrite is required

## Risk

This is a same-major package-manager update. The repository already targets Node.js 22 or newer, so no breaking migration is expected.